### PR TITLE
To call sanji-express like express way

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -27,8 +27,7 @@ module.exports = SanjiExpress = function(app, options) {
   self.router = self.createRouter(self.loader.getRoutes());
 
   // self.createEventPusher(); // enable event pusher (sanji.system.event)
-
-  app.use(self.apiBase, self.router);
+  return self.router;
 };
 
 util.inherits(SanjiExpress, eventEmitter);


### PR DESCRIPTION
I think to call sanji-express must use middleware pattern to avoid user misunderstanding.
